### PR TITLE
Replace inference of ETH with explicit backing_asset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,15 @@ The configuration block for evaluating the balance of an ERC4626 vault token loo
   address_type: "erc4626"
   chain_name: "<the chain name of the RPC node to be used to read this token's information>"
   vault_address: "<the address of the ERC4626 vault asset>"
-  balance_function: "<the optional name of the function to be called to get the wallet's balance of the vault asset; if not specified, defaults to balanceOf>"
+```
+
+You can also provide the following optional fields:
+
+* `balance_function`: the optional name of the function to be called to get the wallet's balance of the vault asset; if not specified, the application will call `balanceOf`
+* `backing_asset`: by default, the applicaiton will try to call `asset` on the given vault address to determine the underlying asset; however, you can specify a `backing_asset` element like so to describe what asset is backing the vault; for assets without a contract address, such as Ether on Ethereum, the `contract_address` field should be set to `""`:
+```
+backing_asset:
+  contract_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 ```
 
 ###### ERC20 Wrapper YNAB Account Configuration

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,7 +127,7 @@ func main() {
 
 			tokenAddress, err = erc4626AssetResolver.ResolveAssetAddress(ctx, erc4626Account)
 			if err != nil {
-				panic(fmt.Sprintf("failed to resolve token address for ERC4626 account '%s': %v", syncableAccount.AccountName, err))
+				panic(fmt.Sprintf("failed to resolve token address for ERC4626 account '%s' with vault address '%s': %v", erc4626Account.AccountName, erc4626Account.VaultAddress, err))
 			}
 
 			tokenBalance, err = erc4626BalanceFetcher.FetchBalance(ctx, erc4626Account)

--- a/config/sync_config.go
+++ b/config/sync_config.go
@@ -368,7 +368,11 @@ type ERC4626BackingAsset struct {
 }
 
 func (e *ERC4626BackingAsset) String() string {
-	return fmt.Sprintf("ERC4626BackingAsset{ContractAddress: %s}", e.ContractAddress)
+	var safeContractAddress string
+	if contractAddress := e.ContractAddress; contractAddress != nil {
+		safeContractAddress = *contractAddress
+	}
+	return fmt.Sprintf("ERC4626BackingAsset{ContractAddress: %s}", safeContractAddress)
 }
 
 // ERC20WrapperAccount defines the properties needed to resolve the balance of an ERC20 wrapper

--- a/config/sync_config.go
+++ b/config/sync_config.go
@@ -11,8 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TODO: add tests
-
 // AddressType is the type of an address
 type AddressType string
 
@@ -276,14 +274,26 @@ type SyncableAccount struct {
 	TransactionCategoryName string // the name of the YNAB category under which the transaction is to be classified
 }
 
+func (s *SyncableAccount) String() string {
+	return fmt.Sprintf("SyncableAccount{AccountName: %s, PayeeName: %s, TransactionCategoryName: %s}", s.AccountName, s.PayeeName, s.TransactionCategoryName)
+}
+
 // OnchainWallet describes a wallet that is onchain.
 type OnchainWallet struct {
 	WalletAddress string // the address to which the asset belongs onchain
 }
 
+func (o *OnchainWallet) String() string {
+	return fmt.Sprintf("OnchainWallet{WalletAddress: %s}", o.WalletAddress)
+}
+
 // OnchainAsset is the descriptor of an asset's onchain presence.
 type OnchainAsset struct {
 	ChainName string // the name of the string on which the asset resides, corresponding to an RPC configuration's chain name
+}
+
+func (o *OnchainAsset) String() string {
+	return fmt.Sprintf("OnchainAsset{ChainName: %s}", o.ChainName)
 }
 
 // ERC20Account defines the properties needed to resolve the balance of an ERC20 token
@@ -297,6 +307,10 @@ type ERC20Account struct {
 
 func (*ERC20Account) isOnchainAccount() {}
 
+func (e *ERC20Account) String() string {
+	return fmt.Sprintf("ERC20Account{SyncableAccount: %s, OnchainAsset: %s, OnchainWallet: %s, TokenAddress: %s}", &e.SyncableAccount, &e.OnchainAsset, &e.OnchainWallet, e.TokenAddress)
+}
+
 // ERC4626Account defines the properties needed to resolve the balance of an ERC4626 vault
 type ERC4626Account struct {
 	SyncableAccount
@@ -309,6 +323,10 @@ type ERC4626Account struct {
 
 func (*ERC4626Account) isOnchainAccount() {}
 
+func (e *ERC4626Account) String() string {
+	return fmt.Sprintf("ERC4626Account{SyncableAccount: %s, OnchainAsset: %s, OnchainWallet: %s, VaultAddress: %s, BalanceFunctionName: %s}", &e.SyncableAccount, &e.OnchainAsset, &e.OnchainWallet, e.VaultAddress, e.BalanceFunctionName)
+}
+
 // ERC20WrapperAccount defines the properties needed to resolve the balance of an ERC20 wrapper
 type ERC20WrapperAccount struct {
 	ERC20Account
@@ -317,3 +335,7 @@ type ERC20WrapperAccount struct {
 }
 
 func (*ERC20WrapperAccount) isOnchainAccount() {}
+
+func (e *ERC20WrapperAccount) String() string {
+	return fmt.Sprintf("ERC20WrapperAccount{ERC20Account: %s, BaseTokenAddressFunction: %s}", &e.ERC20Account, e.BaseTokenAddressFunction)
+}

--- a/token/erc20_asset_resolver_test.go
+++ b/token/erc20_asset_resolver_test.go
@@ -1,6 +1,8 @@
 package token_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -10,15 +12,18 @@ import (
 
 var _ = Describe("ERC20AssetResolver", func() {
 	var erc20AssetResolver *token.ERC20AssetResolver
+	var ctx context.Context
 
 	BeforeEach(func() {
+		ctx = context.Background()
+
 		erc20AssetResolver = token.NewERC20AssetResolver()
 	})
 
 	Describe("ResolveAssetAddress", func() {
 		It("should return the token address", func() {
 			tokenAddress := "0x1234"
-			address, err := erc20AssetResolver.ResolveAssetAddress(nil, &config.ERC20Account{
+			address, err := erc20AssetResolver.ResolveAssetAddress(ctx, &config.ERC20Account{
 				TokenAddress: tokenAddress,
 			})
 			Expect(err).To(BeNil())

--- a/token/erc4626_asset_resolver.go
+++ b/token/erc4626_asset_resolver.go
@@ -26,6 +26,10 @@ func NewERC4626AssetResolver(rpcConfigurationResolver rpcconfig.ConfigurationRes
 }
 
 func (r *ERC4626AssetResolver) ResolveAssetAddress(ctx context.Context, onchainAccount *config.ERC4626Account) (*string, error) {
+	if onchainAccount.VaultAddress == "" {
+		return nil, errors.New("vault address must be provided on the given onchain account")
+	}
+
 	nodeURL, err := ResolveRPCURL(ctx, r.rpcConfigurationResolver, onchainAccount.OnchainAsset, chain.TypeEVM)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve node URL for asset %s: %w", onchainAccount.OnchainAsset, err)

--- a/token/erc4626_asset_resolver.go
+++ b/token/erc4626_asset_resolver.go
@@ -26,6 +26,14 @@ func NewERC4626AssetResolver(rpcConfigurationResolver rpcconfig.ConfigurationRes
 }
 
 func (r *ERC4626AssetResolver) ResolveAssetAddress(ctx context.Context, onchainAccount *config.ERC4626Account) (*string, error) {
+	if onchainAccount == nil {
+		return nil, errors.New("onchain account must be provided")
+	}
+
+	if backingAsset := onchainAccount.BackingAsset; backingAsset != nil {
+		return backingAsset.ContractAddress, nil
+	}
+
 	if onchainAccount.VaultAddress == "" {
 		return nil, errors.New("vault address must be provided on the given onchain account")
 	}
@@ -37,14 +45,7 @@ func (r *ERC4626AssetResolver) ResolveAssetAddress(ctx context.Context, onchainA
 
 	assetAddress, err := rpc.ExecuteEthCall(ctx, r.doer, nodeURL, "asset", onchainAccount.VaultAddress)
 	if err != nil {
-		var rpcError *rpc.RPCCallError
-		if errors.As(err, &rpcError) {
-			// this means that the vault has no asset function; it is assumed to represent an asset with no contract address, such as ETH
-			if rpcError.Code == -32000 {
-				return nil, nil
-			}
-		}
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve asset for ERC4626 account: %w", err)
 	}
 
 	substringAddress := strings.ReplaceAll(assetAddress, "000000000000000000000000", "")

--- a/token/erc4626_asset_resolver_test.go
+++ b/token/erc4626_asset_resolver_test.go
@@ -25,29 +25,11 @@ var _ = Describe("ERC4626AssetResolver", func() {
 
 	When("the contract has an asset function on it", func() {
 		It("returns the address of the asset", func() {
-			vaultAddres := "0x68d30f47F19c07bCCEf4Ac7FAE2Dc12FCa3e0dC9"
+			vaultAddress := "0x68d30f47F19c07bCCEf4Ac7FAE2Dc12FCa3e0dC9"
 			assetAddress := "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"
-			evmNode.RegisterETHCallCall("asset", vaultAddres, nil, func(_ string, _ []string) (rpc.MockEVMNodeRPCResult, *rpc.MockEVMNodeRPCError, error) {
+			evmNode.RegisterETHCallCall("asset", vaultAddress, nil, func(_ string, _ []string) (rpc.MockEVMNodeRPCResult, *rpc.MockEVMNodeRPCError, error) {
 				return rpc.NewMockEVMNodeRPCAddressResult(assetAddress), nil, nil
 			})
-
-			address, err := erc4626AssetResolver.ResolveAssetAddress(ctx, &config.ERC4626Account{
-				OnchainAsset: config.OnchainAsset{
-					ChainName: chainName,
-				},
-				VaultAddress: vaultAddres,
-			})
-
-			Expect(err).ToNot(HaveOccurred(), "resolving the asset address should not fail")
-			Expect(address).ToNot(BeNil(), "the asset address should be returned")
-			Expect(*address).To(Equal(assetAddress), "the asset address should be returned")
-		})
-	})
-
-	When("the contract has no asset function", func() {
-		It("returns nil for the asset address", func() {
-			vaultAddress := "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-			evmNode.RegisterContractExistence(vaultAddress)
 
 			address, err := erc4626AssetResolver.ResolveAssetAddress(ctx, &config.ERC4626Account{
 				OnchainAsset: config.OnchainAsset{
@@ -57,7 +39,8 @@ var _ = Describe("ERC4626AssetResolver", func() {
 			})
 
 			Expect(err).ToNot(HaveOccurred(), "resolving the asset address should not fail")
-			Expect(address).To(BeNil(), "the asset address should be nil")
+			Expect(address).ToNot(BeNil(), "the asset address should be returned")
+			Expect(*address).To(Equal(assetAddress), "the asset address should be returned")
 		})
 	})
 
@@ -70,6 +53,38 @@ var _ = Describe("ERC4626AssetResolver", func() {
 			})
 
 			Expect(err).To(MatchError(ContainSubstring("vault address must be provided on the given onchain account")), "the error should be about the missing vault address")
+		})
+	})
+
+	When("the account has a backing asset specified", func() {
+		It("returns the contract address of the configured backing asset", func() {
+			assetAddress := "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97"
+			address, err := erc4626AssetResolver.ResolveAssetAddress(ctx, &config.ERC4626Account{
+				OnchainAsset: config.OnchainAsset{
+					ChainName: chainName,
+				},
+				BackingAsset: &config.ERC4626BackingAsset{
+					ContractAddress: &assetAddress,
+				},
+			})
+
+			Expect(err).ToNot(HaveOccurred(), "resolving the asset address should not fail")
+			Expect(address).ToNot(BeNil(), "the asset address should be returned")
+			Expect(*address).To(Equal(assetAddress), "the asset address should be returned")
+		})
+
+		When("the backing asset has no contract address", func() {
+			It("returns nil for the contract address to accomodate assets such as ETH", func() {
+				address, err := erc4626AssetResolver.ResolveAssetAddress(ctx, &config.ERC4626Account{
+					OnchainAsset: config.OnchainAsset{
+						ChainName: chainName,
+					},
+					BackingAsset: &config.ERC4626BackingAsset{},
+				})
+
+				Expect(err).ToNot(HaveOccurred(), "resolving the asset address should not fail")
+				Expect(address).To(BeNil(), "the asset address should be nil")
+			})
 		})
 	})
 })

--- a/token/erc4626_asset_resolver_test.go
+++ b/token/erc4626_asset_resolver_test.go
@@ -60,4 +60,16 @@ var _ = Describe("ERC4626AssetResolver", func() {
 			Expect(address).To(BeNil(), "the asset address should be nil")
 		})
 	})
+
+	When("the account has no vault address", func() {
+		It("rejects the request", func() {
+			_, err := erc4626AssetResolver.ResolveAssetAddress(ctx, &config.ERC4626Account{
+				OnchainAsset: config.OnchainAsset{
+					ChainName: chainName,
+				},
+			})
+
+			Expect(err).To(MatchError(ContainSubstring("vault address must be provided on the given onchain account")), "the error should be about the missing vault address")
+		})
+	})
 })


### PR DESCRIPTION
The token resolver for ERC4626 vaults tried to infer that an asset was for ETH if it had no `asset` function based on the error code of RPC error; however, this error code is seemingly inconsistent between RPC providers, making such inference infeasibly unscalable. This change favors just allowing an override configuration and removes the attempted inference.